### PR TITLE
More platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,10 +7,11 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: windows-2012r2
 
 suites:
   - name: default
-    run_list: 
+    run_list:
       - recipe[dotnetcore::default]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: centos-7.1
   - name: windows-2012r2
 
 suites:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,8 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
-default['dotnetcore']['package']['name'] = 'dotnet'
-default['dotnetcore']['package']['version'] = '1.0.0.001675-1'
+default['dotnetcore']['package']['name'] = 'dotnet-dev-1.0.0-preview2-003131'
 default['dotnetcore']['package']['source_url'] = 'https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/1.0.0.001675/dotnet-win-x64.1.0.0.001675.exe'
 
 default['dotnetcore']['apt_package_source'] = 'http://apt-mo.trafficmanager.net/repos/dotnet'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,13 @@ long_description 'Installs/Configures dotnetcore'
 version          '1.1.0'
 
 depends 'apt', '~> 2.9.2'
+depends 'tar'
 
 supports 'ubuntu', '= 14.04'
+supports 'ubuntu', '= 16.04'
+supports 'centos', '= 7.1'
+supports 'oracle', '= 7.1'
+supports 'amazon'
 supports 'windows'
 
 provides 'dotnetcore::default'

--- a/recipes/_platform.rb
+++ b/recipes/_platform.rb
@@ -12,6 +12,8 @@ when 'windows'
     include_recipe 'dotnetcore::_windows'
 when 'debian', 'ubuntu'
     include_recipe 'dotnetcore::_ubuntu'
+when 'centos', 'amazon', 'oracle'
+    include_recipe 'dotnetcore::_tar_install'
 else
-    fail 'This cookbook currently only supports Debian/Ubuntu and Windows.'
+    fail 'This cookbook currently only supports Debian/Ubuntu, CentOS/Amazon/Oracle, and Windows.'
 end

--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -6,6 +6,8 @@
 #
 # All rights reserved - Do Not Redistribute
 #
+# Installs dotnetcore using the tar instructions intended for CentOS, Oracle Linux, and Amazon
+# https://www.microsoft.com/net/core#centos
 
 package 'libunwind'
 package 'libicu'
@@ -19,6 +21,6 @@ tar_extract 'https://go.microsoft.com/fwlink/?LinkID=827529' do
   creates '/opt/dotnet/dotnet'
 end
 
-link '/opt/dotnet/dotnet' do
-  to '/usr/local/bin/dotnet'
+link '/usr/local/bin/dotnet' do
+  to '/opt/dotnet/dotnet'
 end

--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: dotnetcore
+# Recipe:: _tar_install
+#
+# Copyright (C) 2016 Andrew Cornies
+#
+# All rights reserved - Do Not Redistribute
+#
+
+package 'libunwind'
+package 'libicu'
+
+directory '/opt/dotnet' do
+  recursive true
+end
+
+tar_extract 'https://go.microsoft.com/fwlink/?LinkID=827529' do
+  target_dir '/opt/dotnet'
+  creates '/opt/dotnet/dotnet'
+end
+
+link '/opt/dotnet/dotnet' do
+  to '/usr/local/bin/dotnet'
+end

--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -21,6 +21,6 @@ tar_extract 'https://go.microsoft.com/fwlink/?LinkID=827529' do
   creates '/opt/dotnet/dotnet'
 end
 
-link '/usr/local/bin/dotnet' do
+link '/usr/bin/dotnet' do
   to '/opt/dotnet/dotnet'
 end

--- a/recipes/_ubuntu.rb
+++ b/recipes/_ubuntu.rb
@@ -7,6 +7,10 @@
 # All rights reserved - Do Not Redistribute
 #
 
+unless %w(trusty xenial).include? node['lsb']['codename']
+  fail 'Only Ubuntu 14.04 (trusty), and 16.04 (xenial), and their dirivatives (Linux Mint) are supported by dotnetcore'
+end
+
 include_recipe 'apt::default' do
     only_if { !node.has_recipe?('apt::default') }
 end
@@ -14,12 +18,11 @@ end
 apt_repository 'dotnetdev' do
     uri node['dotnetcore']['apt_package_source']
     components ['main']
-    distribution 'trusty'
+    distribution node['lsb']['codename']
     arch 'amd64'
     key node['dotnetcore']['apt_package_source_key']
 end
 
 package node['dotnetcore']['package']['name'] do
-    version node['dotnetcore']['package']['version']
     options '--force-yes'
 end

--- a/test/integration/default/serverspec/dotnet_spec.rb
+++ b/test/integration/default/serverspec/dotnet_spec.rb
@@ -16,6 +16,10 @@ when 'ubuntu'
     describe command('dotnet --help') do
         its(:stdout) { should match /.NET Command Line Tools / }
     end
+when 'centos', 'amazon', 'oracle'
+  describe command('dotnet --help') do
+      its(:stdout) { should match /.NET Command Line Tools / }
+  end
 end
 
 #Agnostic tests below

--- a/test/integration/default/serverspec/dotnet_spec.rb
+++ b/test/integration/default/serverspec/dotnet_spec.rb
@@ -9,14 +9,13 @@ when 'windows'
 
 when 'ubuntu'
 
-    describe package('dotnet') do
+    describe package('dotnet-dev-1.0.0-preview2-003131') do
         it { should be_installed }
-    end 
-    
-    describe command('dotnet --version') do
-        its(:stdout) { should match /.NET Command Line Tools / }
-    end 
+    end
 
+    describe command('dotnet --help') do
+        its(:stdout) { should match /.NET Command Line Tools / }
+    end
 end
 
 #Agnostic tests below


### PR DESCRIPTION
Adds support for Ubuntu 16.04 (had to use the full package name as per the [instructions](https://www.microsoft.com/net/core#ubuntu)).

Also adds support for CentOS and Oracle Linux (and amazon byproxy, tested externally as there is no amazon vagrant box).

Can't seem to get the tests running for windows at all as it can't find the box, but I haven't changed anything there
