### PR TITLE
Allow dotnetcore upgrade when using tar install method

### DIFF
--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -18,7 +18,6 @@ end
 
 tar_extract node['dotnetcore']['package']['tar'] do
   target_dir '/opt/dotnet'
-  creates '/opt/dotnet/dotnet'
 end
 
 link '/usr/bin/dotnet' do


### PR DESCRIPTION
This patch makes sure we can upgrade dotnetcore.

Before the patch, `creates` property prevented the downloaded tarball to
be extracted
(https://github.com/chef-cookbooks/tar/blob/3d659bd87bbdc32805d07b56bf531a04497b0066/resources/extract.rb#L92)
because the /opt/dotnet/dotnet exist after a first extraction.

tar_extract resource is fallbacks to chef notifications when not giving
`creates` which is the expected behavior

Fixes #16

Change-Id: Icc3c85e59890b7a6e1189d6a73b6a180cfe24afc